### PR TITLE
Timeout to all Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
 
     strategy:
       matrix:

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   build_and_release:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
 
     strategy:
       matrix:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,6 +12,7 @@ jobs:
   coverage:
     name: coverage
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,6 +8,7 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -12,6 +12,7 @@ jobs:
   unit:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/test/integration_testing/spec.js
+++ b/test/integration_testing/spec.js
@@ -5,32 +5,8 @@ const path = require('path')
 
 describe('Application launch', function () {
   this.timeout(10000)
-  //this.app.start()
-  /*
-  this.app = new Application({
-      // Your electron path can be any binary
-      // i.e for OSX an example path could be '/Applications/MyApp.app/Contents/MacOS/MyApp'
-      // But for the sake of the example we fetch it from our node_modules.
-      path: electronPath,
 
-      // Assuming you have the following directory structure
-
-      //  |__ my project
-      //     |__ ...
-      //     |__ main.js
-      //     |__ package.json
-      //     |__ index.html
-      //     |__ ...
-      //     |__ test
-      //        |__ spec.js  <- You are here! ~ Well you should be.
-
-      // The following line tells spectron to look and use the main.js file
-      // and the package.json located 1 level above.
-      args: [path.join(__dirname, '../..')]
-      })
-  this.app.start()*/
-  before(function () { 
-
+  beforeEach(function () {
     this.app = new Application({
       // Your electron path can be any binary
       // i.e for OSX an example path could be '/Applications/MyApp.app/Contents/MacOS/MyApp'
@@ -54,28 +30,18 @@ describe('Application launch', function () {
     })
     return this.app.start()
   })
-  //this.app.start();
+
   afterEach(function () {
     if (this.app && this.app.isRunning()) {
-      //return this.app.stop()
+      return this.app.stop()
     }
-  })/*
-  it('shows an initial window', function () { 
+  })
+
+  it('shows an initial window', function () {
     return this.app.client.getWindowCount().then(function (count) {
       assert.equal(count, 1)
       // Please note that getWindowCount() will return 2 if `dev tools` are opened.
       // assert.equal(count, 2)
     })
-  })*/
-  
-  it('sign-in', function () {
-    this.app.client.$('#signInBtn').click()
-    this.app.client.waitUntil(this.app.client.isExisting('#signInBtn')).then(function(){
-    	this.app.client.$('#signInBtn').click()
-    })
-    return
-	    //() =>
-      // Please note that getWindowCount() will return 2 if `dev tools` are opened.
-      // assert.equal(count, 2)
-    })
+  })
 })


### PR DESCRIPTION
Waiting 360 minutes for a test to fail is silly and leads to cancellations. Added a 5 min timeout to all actions.