### PR TITLE
Restructured Release Process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,9 +32,7 @@ jobs:
         uses: git pull tag origin master  
        
       - name: look at list of tags
-        env:
-          pulled_version: cat package.json | grep version | head -1 | awk '{print $2}' | sed 's/[\",]//g' | tr -d '[[:space:]]')
-        run: git tag -l ${{pulled_version}}
+        run: git tag -l foo=$(cat package.json | grep version | head -1 | awk '{print $2}' | sed 's/[\",]//g' | perl -ne 'print "v$_"') && git tag -l ${foo}
 
      
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,19 +20,22 @@ jobs:
         os: [macos-latest, windows-latest]
 
     steps:
-
+      
       - name: Check out Git repository
       
         uses: actions/checkout@v1
 
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v1
-
-     # - name:
-    #   run: ${{ contains(git -l github.ref, '') }}
+        
+        env:
+          PULLED_VERSION = cat package.json | grep version | head -1 | awk -F: '{print $2}' | sed 's/[\",]//g' | tr -d '[[:space:]]'
+        
+      - name: pull tag
+        uses: git pull tag origin master  
        
-      - name:
-        run: git tag -l
+      - name: look at list of tags
+        run: git tag -l $PULLED_VERSION     
         
       - name:
         run: ${{github.ref}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,12 +29,12 @@ jobs:
         uses: actions/setup-node@v1
         
       - name: get package version
-        run: ::set-env name=PACKAGE_VER::$(cat package.json | grep version | head -1 | awk '{print $2}' | sed 's/[\",]//g' | perl -ne 'print "v$_"')
+        run: echo "::set-env name=PACKAGE_VER::$(cat package.json | grep version | head -1 | awk '{print $2}' | sed 's/[\",]//g' | perl -ne 'print "v$_"')"
       - name: print result
         run: echo env.PACKAGE_VER
        
       - name: set env
-        run: ::set-env name=NEW_VERSION::$(git tag -l env.PACKAGE_VER)
+        run: echo "::set-env name=NEW_VERSION::$(git tag -l env.PACKAGE_VER)"
       - name: print result
         run: echo env.NEW_VERSION
       

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,40 +11,55 @@ on:
      # - master
 
 jobs:
-  build_and_release:
-    runs-on: ${{ matrix.os }}
+  build_and_release_mac:
+    runs-on: macos-latest
     timeout-minutes: 5
-
-    strategy:
-      matrix:
-        os: [macos-latest, windows-latest]
-
+    outputs:
+      output1: ${{ steps.setoutput.outputs.release }}
     steps:
+      - id: checkout
+        uses: actions/checkout@v1
+
+      - id: intallnpm
+        uses: actions/setup-node@v1
+        
+      - id: packageversion
+        run: echo "::set-env name=PACKAGE_VER::$(cat package.json | grep version | head -1 | awk '{print $2}' | sed 's/[\",]//g' | perl -ne 'print "v$_"')"
+       
+      - id: newrelease
+        run: echo "::set-env name=NEW_VERSION::$(git tag -l ${{env.PACKAGE_VER}})"  
+        
+      - id: tag
+        if: ${{!contains(env.NEW_VERSION, env.PACKAGE_VER)}}
+        run: git tag ${{env.PACKAGE_VER}}
+        
+      - id: setoutput
+        if: ${{!contains(env.NEW_VERSION, env.PACKAGE_VER)}}
+        run: echo "::set-output name=release::true"
       
+
+      - id: Build and Release Electron app
+        if: ${{!contains(env.NEW_VERSION, env.PACKAGE_VER)}}
+        uses: samuelmeuli/action-electron-builder@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+
+          release: true
+          
+  build_and_release_windows:
+    runs-on: windows-latest
+    timeout-minutes: 5
+    needs: build_and_release_mac
+     
       - name: Check out Git repository
       
         uses: actions/checkout@v1
 
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v1
-        
-      - name: get package version
-        run: echo "::set-env name=PACKAGE_VER::$(cat package.json | grep version | head -1 | awk '{print $2}' | sed 's/[\",]//g' | perl -ne 'print "v$_"')"
-     # - name: print result
-     #   run: echo ${{env.PACKAGE_VER}}
-       
-      - name: get if package version is already tagged
-        run: echo "::set-env name=NEW_VERSION::$(git tag -l ${{env.PACKAGE_VER}})"
-     # - name: print result
-     #   run: echo ${{env.NEW_VERSION}}
-        
-        
-      - name: Create Tag
-        if: ${{!contains(env.NEW_VERSION, env.PACKAGE_VER)}}
-        run: git tag ${{env.PACKAGE_VER}}
 
       - name: Build and Release Electron app
-        if: ${{!contains(env.NEW_VERSION, env.PACKAGE_VER)}}
+        if: ${{needs.build_and_release_mac.outputs.output1}}
         uses: samuelmeuli/action-electron-builder@v1
         with:
           # GitHub token, automatically provided to the action

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,9 +50,8 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 5
     needs: build_and_release_mac
-     
+    steps:
       - name: Check out Git repository
-      
         uses: actions/checkout@v1
 
       - name: Install Node.js, NPM and Yarn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,7 @@ jobs:
       uses: anothrNick/github-tag-action@1.17.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        RELEASE_BRANCHES : build
         CUSTOM_TAG: ${{env.PACKAGE_VER}}
     
     

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,16 +27,13 @@ jobs:
 
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v1
+        
+      - name: get package version
+        run: echo ::set-env name=PACKAGE_VER::$(cat package.json | grep version | head -1 | awk '{print $2}' | sed 's/[\",]//g' | perl -ne 'print "v$_"')
        
       - name: set env
-        run: echo ::set-env name=VERSION::$(git tag -l foo=$(cat package.json | grep version | head -1 | awk '{print $2}' | sed 's/[\",]//g' | perl -ne 'print "v$_"') && git tag -l ${foo})
+        run: echo ::set-env name=NEW_VERSION::$(git tag -l env.PACKAGE_VER)
         
-        
-      - name: echo
-        run: echo $VERSION
-        
-      - name: contains
-        run: ${{ contains(env.VERSION, "v1.0.4")}}
       
      
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,6 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest]
-    timeout-minutes: 5
     needs: tagger
     
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,8 @@ jobs:
         run: git tag -l
         
       - name:
+        run: ${{github.ref}}
+      - name:
         run: ${{contains(github.ref, 'release')}}
 
       - name: Build/release Electron app

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
        
       - name: look at list of tags
         env:
-          pulled_version: ${{cat package.json | grep version | head -1 | awk '{print $2}' | sed 's/[\",]//g' | tr -d '[[:space:]]')}}
+          pulled_version: cat package.json | grep version | head -1 | awk '{print $2}' | sed 's/[\",]//g' | tr -d '[[:space:]]')
         run: git tag -l ${{pulled_version}}
 
      

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,11 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v1
 
+     # - name:
+    #   run: ${{ contains(git -l github.ref, '') }}
+       
       - name:
-        run: ${{ contains(git -l github.ref, '') }}
+        run: git status
 
       - name: Build/release Electron app
         uses: samuelmeuli/action-electron-builder@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,11 +29,14 @@ jobs:
         uses: actions/setup-node@v1
         
       - name: get package version
-        run: echo ::set-env name=PACKAGE_VER::$(cat package.json | grep version | head -1 | awk '{print $2}' | sed 's/[\",]//g' | perl -ne 'print "v$_"')
+        run: set-env name=PACKAGE_VER::$(cat package.json | grep version | head -1 | awk '{print $2}' | sed 's/[\",]//g' | perl -ne 'print "v$_"')
+      - name: print result
+        run: echo env.PACKAGE_VER
        
       - name: set env
-        run: echo ::set-env name=NEW_VERSION::$(git tag -l env.PACKAGE_VER)
-        
+        run: set-env name=NEW_VERSION::$(git tag -l env.PACKAGE_VER)
+      - name: print result
+        run: echo env.NEW_VERSION
       
      
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ name: release
 on:
   push:
     branches:
-      - master
+     # - master
 
 jobs:
   build_and_release:
@@ -28,6 +28,8 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v1
 
+      - name:
+        run: ${{ contains(git -l github.ref, '') }}
 
       - name: Build/release Electron app
         uses: samuelmeuli/action-electron-builder@v1
@@ -38,4 +40,4 @@ jobs:
 
           # If the commit is tagged with a version (e.g. "v1.0.0"),
           # release the app after building
-          release: ${{ startsWith(github.ref, 'refs/tags/v') }}
+          release: false  #${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         run: echo $VERSION
         
       - name: contains
-        run: ${{ contains($VERSION, "v1.0.4")}}
+        run: ${{ contains(env.VERSION, "v1.0.4")}}
       
      
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         run: echo $VERSION
         
       - name: contains
-        run: ${{ contains(VERSION, "v1.0.4")}}
+        run: ${{ contains($VERSION, "v1.0.4")}}
       
      
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,12 +29,12 @@ jobs:
         uses: actions/setup-node@v1
         
       - name: get package version
-        run: set-env name=PACKAGE_VER::$(cat package.json | grep version | head -1 | awk '{print $2}' | sed 's/[\",]//g' | perl -ne 'print "v$_"')
+        run: ::set-env name=PACKAGE_VER::$(cat package.json | grep version | head -1 | awk '{print $2}' | sed 's/[\",]//g' | perl -ne 'print "v$_"')
       - name: print result
         run: echo env.PACKAGE_VER
        
       - name: set env
-        run: set-env name=NEW_VERSION::$(git tag -l env.PACKAGE_VER)
+        run: ::set-env name=NEW_VERSION::$(git tag -l env.PACKAGE_VER)
       - name: print result
         run: echo env.NEW_VERSION
       

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,5 @@
 # Source
 # https://github.com/samuelmeuli/action-electron-builder
-
 # See README on use
 
 name: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,10 @@ jobs:
         uses: git pull tag origin master  
        
       - name: look at list of tags
+        env:
+          pulled_version: ${{cat package.json | grep version | head -1 | awk '{print $2}' | sed 's/[\",]//g' | tr -d '[[:space:]]')}}
         run: git tag -l ${{pulled_version}}
+
      
 
       - name: Build/release Electron app
@@ -45,5 +48,3 @@ jobs:
           # If the commit is tagged with a version (e.g. "v1.0.0"),
           # release the app after building
           release: false  #${{ startsWith(github.ref, 'refs/tags/v') }}
-        env:
-          pulled_version: ${{cat package.json | grep version | head -1 | awk '{print $2}' | sed 's/[\",]//g' | tr -d '[[:space:]]')}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,4 +46,4 @@ jobs:
           # release the app after building
           release: false  #${{ startsWith(github.ref, 'refs/tags/v') }}
         env:
-          pulled_version: $(cat package.json | grep version | head -1 | awk '{print $2}' | sed 's/[\",]//g' | tr -d '[[:space:]]')
+          pulled_version: ${{cat package.json | grep version | head -1 | awk '{print $2}' | sed 's/[\",]//g' | tr -d '[[:space:]]')}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         
         
       - name: echo
-        run echo $VERSION
+        run: echo $VERSION
       
      
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,12 +11,12 @@ on:
      # - master
 
 jobs:
-  
   tagger:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
       output1: ${{ steps.setoutput.outputs.release }}
+      
     steps:
     - uses: actions/checkout@master
       with:
@@ -28,7 +28,6 @@ jobs:
     - name: check for existing tags
       run: echo "::set-env name=NEW_VERSION::$(git tag -l ${{env.PACKAGE_VER}})"  
       
-    - name: Update release variable  
     - id: setoutput
       if: ${{!contains(env.NEW_VERSION, env.PACKAGE_VER)}}
       run: echo "::set-output name=release::true"
@@ -49,6 +48,7 @@ jobs:
         os: [macos-latest, windows-latest]
     timeout-minutes: 5
     needs: tagger
+    
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         run: echo ${{env.PACKAGE_VER}}
        
       - name: get if package version is already tagged
-        run: echo "::set-env name=NEW_VERSION::$(git tag -l env.PACKAGE_VER)"
+        run: echo "::set-env name=NEW_VERSION::$(git tag -l ${{env.PACKAGE_VER}})"
       - name: print result
         run: echo ${{env.NEW_VERSION}}
         

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ name: release
 on:
   push:
     branches:
-     # - master
+      - master
 
 jobs:
   tagger:
@@ -36,7 +36,7 @@ jobs:
       uses: anothrNick/github-tag-action@1.17.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        RELEASE_BRANCHES : build
+        RELEASE_BRANCHES : master
         CUSTOM_TAG: ${{env.PACKAGE_VER}}
     
     

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,9 @@ jobs:
         
       - name: echo
         run: echo $VERSION
+        
+      - name: contains
+        run: ${{ contains(VERSION, "v1.0.4")}}
       
      
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,13 +27,14 @@ jobs:
 
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v1
-        
-      - name: pull tag
-        uses: git pull tag origin master  
        
-      - name: look at list of tags
-        run: git tag -l foo=$(cat package.json | grep version | head -1 | awk '{print $2}' | sed 's/[\",]//g' | perl -ne 'print "v$_"') && git tag -l ${foo}
-
+      - name: set env
+        run: echo ::set-env name=VERSION::$(git tag -l foo=$(cat package.json | grep version | head -1 | awk '{print $2}' | sed 's/[\",]//g' | perl -ne 'print "v$_"') && git tag -l ${foo})
+        
+        
+      - name: echo
+        run echo $VERSION
+      
      
 
       - name: Build/release Electron app

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,14 +31,17 @@ jobs:
       - name: get package version
         run: echo "::set-env name=PACKAGE_VER::$(cat package.json | grep version | head -1 | awk '{print $2}' | sed 's/[\",]//g' | perl -ne 'print "v$_"')"
       - name: print result
-        run: echo env.PACKAGE_VER
+        run: echo ${{env.PACKAGE_VER}}
        
-      - name: set env
+      - name: get if package version is already tagged
         run: echo "::set-env name=NEW_VERSION::$(git tag -l env.PACKAGE_VER)"
       - name: print result
-        run: echo env.NEW_VERSION
-      
-     
+        run: echo ${{env.NEW_VERSION}}
+        
+        
+      - name: runner
+        if: !contains(env.NEW_VERSION, env.PACKAGE_VER)
+        run: echo doesnt contain #git tag ${{env.PACKAGE_VER}}
 
       - name: Build/release Electron app
         uses: samuelmeuli/action-electron-builder@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,19 +28,12 @@ jobs:
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v1
         
-        env:
-          PULLED_VERSION = cat package.json | grep version | head -1 | awk -F: '{print $2}' | sed 's/[\",]//g' | tr -d '[[:space:]]'
-        
       - name: pull tag
         uses: git pull tag origin master  
        
       - name: look at list of tags
-        run: git tag -l $PULLED_VERSION     
-        
-      - name:
-        run: ${{github.ref}}
-      - name:
-        run: ${{contains(github.ref, 'release')}}
+        run: git tag -l cat package.json | grep version | head -1 | awk -F: '{print $2}' | sed 's/[\",]//g' | tr -d '[[:space:]]'     
+      
 
       - name: Build/release Electron app
         uses: samuelmeuli/action-electron-builder@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,8 @@ jobs:
         uses: git pull tag origin master  
        
       - name: look at list of tags
-        run: git tag -l cat package.json | grep version | head -1 | awk -F: '{print $2}' | sed 's/[\",]//g' | tr -d '[[:space:]]'     
-      
+        run: git tag -l ${{pulled_version}}
+     
 
       - name: Build/release Electron app
         uses: samuelmeuli/action-electron-builder@v1
@@ -45,3 +45,5 @@ jobs:
           # If the commit is tagged with a version (e.g. "v1.0.0"),
           # release the app after building
           release: false  #${{ startsWith(github.ref, 'refs/tags/v') }}
+        env:
+          pulled_version: $(cat package.json | grep version | head -1 | awk '{print $2}' | sed 's/[\",]//g' | tr -d '[[:space:]]')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,9 +36,8 @@ jobs:
       - id: setoutput
         if: ${{!contains(env.NEW_VERSION, env.PACKAGE_VER)}}
         run: echo "::set-output name=release::true"
-      
 
-      - id: Build and Release Electron app
+      - id: buildandrelease
         if: ${{!contains(env.NEW_VERSION, env.PACKAGE_VER)}}
         uses: samuelmeuli/action-electron-builder@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,13 +30,13 @@ jobs:
         
       - name: get package version
         run: echo "::set-env name=PACKAGE_VER::$(cat package.json | grep version | head -1 | awk '{print $2}' | sed 's/[\",]//g' | perl -ne 'print "v$_"')"
-      - name: print result
-        run: echo ${{env.PACKAGE_VER}}
+     # - name: print result
+     #   run: echo ${{env.PACKAGE_VER}}
        
       - name: get if package version is already tagged
         run: echo "::set-env name=NEW_VERSION::$(git tag -l ${{env.PACKAGE_VER}})"
-      - name: print result
-        run: echo ${{env.NEW_VERSION}}
+     # - name: print result
+     #   run: echo ${{env.NEW_VERSION}}
         
         
       - name: Create Tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         
         
       - name: runner
-        if: !contains(env.NEW_VERSION, env.PACKAGE_VER)
+        if: ${{!contains(env.NEW_VERSION, env.PACKAGE_VER)}}
         run: echo doesnt contain #git tag ${{env.PACKAGE_VER}}
 
       - name: Build/release Electron app

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,10 @@ jobs:
     #   run: ${{ contains(git -l github.ref, '') }}
        
       - name:
-        run: git status
+        run: git tag -l
+        
+      - name:
+        run: ${{contains(github.ref, 'release')}}
 
       - name: Build/release Electron app
         uses: samuelmeuli/action-electron-builder@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,11 +39,12 @@ jobs:
         run: echo ${{env.NEW_VERSION}}
         
         
-      - name: runner
+      - name: Create Tag
         if: ${{!contains(env.NEW_VERSION, env.PACKAGE_VER)}}
-        run: echo doesnt contain #git tag ${{env.PACKAGE_VER}}
+        run: git tag ${{env.PACKAGE_VER}}
 
-      - name: Build/release Electron app
+      - name: Build and Release Electron app
+        if: ${{!contains(env.NEW_VERSION, env.PACKAGE_VER)}}
         uses: samuelmeuli/action-electron-builder@v1
         with:
           # GitHub token, automatically provided to the action
@@ -52,4 +53,4 @@ jobs:
 
           # If the commit is tagged with a version (e.g. "v1.0.0"),
           # release the app after building
-          release: false  #${{ startsWith(github.ref, 'refs/tags/v') }}
+          release: true  #${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,44 +11,44 @@ on:
      # - master
 
 jobs:
-  build_and_release_mac:
-    runs-on: macos-latest
+  
+  tagger:
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
       output1: ${{ steps.setoutput.outputs.release }}
     steps:
-      - id: checkout
-        uses: actions/checkout@v1
-
-      - id: intallnpm
-        uses: actions/setup-node@v1
+    - uses: actions/checkout@master
+      with:
+        fetch-depth: '0'
         
-      - id: packageversion
-        run: echo "::set-env name=PACKAGE_VER::$(cat package.json | grep version | head -1 | awk '{print $2}' | sed 's/[\",]//g' | perl -ne 'print "v$_"')"
-       
-      - id: newrelease
-        run: echo "::set-env name=NEW_VERSION::$(git tag -l ${{env.PACKAGE_VER}})"  
-        
-      - id: tag
-        if: ${{!contains(env.NEW_VERSION, env.PACKAGE_VER)}}
-        run: git tag ${{env.PACKAGE_VER}}
-        
-      - id: setoutput
-        if: ${{!contains(env.NEW_VERSION, env.PACKAGE_VER)}}
-        run: echo "::set-output name=release::true"
-
-      - id: buildandrelease
-        if: ${{!contains(env.NEW_VERSION, env.PACKAGE_VER)}}
-        uses: samuelmeuli/action-electron-builder@v1
-        with:
-          github_token: ${{ secrets.github_token }}
-
-          release: true
-          
-  build_and_release_windows:
-    runs-on: windows-latest
+    - name: get package version
+      run: echo "::set-env name=PACKAGE_VER::$(cat package.json | grep version | head -1 | awk '{print $2}' | sed 's/[\",]//g' | perl -ne 'print "v$_"')"
+    
+    - name: check for existing tags
+      run: echo "::set-env name=NEW_VERSION::$(git tag -l ${{env.PACKAGE_VER}})"  
+      
+    - name: Update release variable  
+    - id: setoutput
+      if: ${{!contains(env.NEW_VERSION, env.PACKAGE_VER)}}
+      run: echo "::set-output name=release::true"
+      
+    - name: Bump version and push tag
+      if: ${{!contains(env.NEW_VERSION, env.PACKAGE_VER)}}
+      uses: anothrNick/github-tag-action@1.17.2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        CUSTOM_TAG: ${{env.PACKAGE_VER}}
+    
+    
+  build_and_release:
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 5
-    needs: build_and_release_mac
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest]
+    timeout-minutes: 5
+    needs: tagger
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v1
@@ -57,13 +57,8 @@ jobs:
         uses: actions/setup-node@v1
 
       - name: Build and Release Electron app
-        if: ${{needs.build_and_release_mac.outputs.output1}}
+        if: ${{needs.tagger.outputs.output1}}
         uses: samuelmeuli/action-electron-builder@v1
         with:
-          # GitHub token, automatically provided to the action
-          # (No need to define this secret in the repo settings)
           github_token: ${{ secrets.github_token }}
-
-          # If the commit is tagged with a version (e.g. "v1.0.0"),
-          # release the app after building
-          release: true  #${{ startsWith(github.ref, 'refs/tags/v') }}
+          release: true

--- a/README.md
+++ b/README.md
@@ -70,15 +70,15 @@ Integration Testing
 
 
 ## Release
-  This is done through Gitub Actions.
+  This is done through Gitub Actions. All it really looks for is for a different version
+  in package.json then what master currently has.
   
-    1. Update the version in your project's package.json file (e.g. 1.2.3).
+    1. Update the version in your project's package.json file (e.g. 1.2.3). If this is
+	   not a new version the release will not function. 
     2. Commit that change (git commit -am v1.2.3).
-    3. Tag your commit (git tag v1.2.3). Make sure your tag name's format is
-       v*.*.*. Your workflow will use this tag to detect when to create a release.
-    4. Push your changes to GitHub (git push && git push --tags).
+    4. Push your changes to GitHub
     5. Create a pull request to merge changes into master.
-    6. Go to the release tab in GHithub. There will now be a Draft of the taged commit
+    6. Go to the release tab in Github. There will now be a Draft of the taged commit
       click edit, make any changes you wish and publish the draft to release to the
       public.
     

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
    "category": "Office"
   }
  },
- "version": "1.0.4",
+ "version": "1.0.5",
  "description": "",
  "main": "./app/main.js",
  "scripts": {


### PR DESCRIPTION
Figured out how to properly put out release when masters version number in package.json differs from a new push coming into master. No tagging needed. This should make updating our current version quite easy to do.

Now release has a "tagger" job that looks to see if we need to release a new build. That job will enable the other release jobs to function if it ends up putting out a new tag.

Github Actions is a real pain to work around. There are so many commits as I was trying to feel my way around the right way to do this.  

The basic idea is that i use bash to grab the version number and format it to just a vx.x.x format and run that into git tag -l vx.x.x if there is no output then there is no releases for that version yet, and we just trigger the release jobs. 